### PR TITLE
feat: CrewAI + LangChain adapters, MCP server, docs site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,46 @@
+name: Deploy docs to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+    paths: ["docs/**"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,21 @@
+title: MIF — Memory Interchange Format
+description: A vendor-neutral JSON schema for portable AI agent memories
+remote_theme: just-the-docs/just-the-docs
+
+url: "https://varun29ankus.github.io"
+baseurl: "/mif-spec"
+
+aux_links:
+  "GitHub":
+    - "https://github.com/varun29ankuS/mif-spec"
+  "PyPI":
+    - "https://pypi.org/project/mif-tools/"
+  "npm":
+    - "https://www.npmjs.com/package/@varunshodh/mif-tools"
+
+nav_enabled: true
+search_enabled: true
+
+footer_content: "MIF is open source under the Apache 2.0 License."
+
+color_scheme: dark

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -1,0 +1,211 @@
+---
+layout: default
+title: Adapters
+nav_order: 3
+---
+
+# Format Adapters
+
+MIF tools include adapters for converting between popular AI memory formats and MIF v2.
+
+---
+
+## Shodh / MIF Native (`shodh`)
+
+The native MIF v2 format. Also handles backward-compatible import of MIF v1 documents.
+
+**Detection:** JSON object with `"mif_version"` or `"shodh-memory"` key.
+
+```json
+{
+  "mif_version": "2.0",
+  "memories": [
+    { "id": "...", "content": "...", "created_at": "..." }
+  ]
+}
+```
+
+---
+
+## mem0 (`mem0`)
+
+Converts [mem0](https://mem0.ai) JSON array exports.
+
+**Detection:** JSON array where items have a `"memory"` field.
+
+```json
+[
+  {
+    "id": "...",
+    "memory": "User prefers TypeScript",
+    "user_id": "user-42",
+    "created_at": "2025-06-15T12:00:00Z",
+    "metadata": { "category": "preference" }
+  }
+]
+```
+
+**Field mapping:**
+
+| mem0 | MIF |
+|---|---|
+| `memory` | `content` |
+| `id` | `external_id` + `id` (preserved if valid UUID) |
+| `metadata.category` | `memory_type` (via mapping table) |
+| `metadata.tags` | `tags` (comma-separated string or array) |
+| `user_id` | `export_meta.user_id` |
+
+---
+
+## CrewAI (`crewai`)
+
+Converts [CrewAI](https://crewai.com) long-term memory exports from LTMSQLiteStorage.
+
+**Detection:** JSON array where items have a `"task_description"` field.
+
+```json
+[
+  {
+    "task_description": "User prefers dark mode for all IDEs",
+    "metadata": "{\"category\": \"preference\"}",
+    "datetime": "1718452800.0",
+    "score": 0.95
+  }
+]
+```
+
+**Field mapping:**
+
+| CrewAI | MIF |
+|---|---|
+| `task_description` | `content` |
+| `metadata` (JSON string) | `metadata` (parsed to object) |
+| `datetime` (Unix timestamp) | `created_at` (ISO 8601) |
+| `score` | `metadata.score` |
+
+---
+
+## LangChain / LangMem (`langchain`)
+
+Converts [LangChain](https://langchain.com) and [LangMem](https://langchain-ai.github.io/langmem/) Item objects.
+
+**Detection:** JSON array where items have `"namespace"` and `"value"` fields.
+
+```json
+[
+  {
+    "namespace": ["memories", "user-prefs"],
+    "key": "pref-dark-mode",
+    "value": { "kind": "Memory", "content": "User prefers dark mode" },
+    "created_at": "2025-06-15T12:00:00Z",
+    "score": 0.9
+  }
+]
+```
+
+**Field mapping:**
+
+| LangChain | MIF |
+|---|---|
+| `value.content` | `content` |
+| `value.kind` | `memory_type` (lowercased, mapped) |
+| `namespace` | `tags` (flattened) |
+| `key` | `external_id` |
+| `created_at` | `created_at` |
+| `updated_at` | `updated_at` |
+| `score` | `metadata.score` |
+
+---
+
+## Generic JSON (`generic`)
+
+Fallback adapter for any JSON array with a `content` field.
+
+**Detection:** JSON array where items have a `"content"` field.
+
+```json
+[
+  {
+    "content": "Remember to check logs daily",
+    "type": "task",
+    "timestamp": "2025-06-15T12:00:00Z",
+    "tags": ["ops"]
+  }
+]
+```
+
+Accepts `timestamp`, `created_at`, or `date` for the creation time. Accepts `type` or `memory_type` for the memory type.
+
+---
+
+## Markdown (`markdown`)
+
+YAML frontmatter + body format. Each memory is a `---` delimited block.
+
+**Detection:** Input starts with `---`.
+
+```markdown
+---
+type: observation
+created_at: 2025-06-15T12:00:00Z
+tags: [python, testing]
+---
+User prefers pytest over unittest.
+```
+
+---
+
+## Writing Custom Adapters
+
+### Python
+
+```python
+from mif.adapters import MifAdapter
+from mif.models import MifDocument
+
+class MyAdapter(MifAdapter):
+    def name(self) -> str:
+        return "My Format"
+
+    def format_id(self) -> str:
+        return "myformat"
+
+    def detect(self, data: str) -> bool:
+        return '"my_marker"' in data
+
+    def to_mif(self, data: str) -> MifDocument:
+        # Parse data and return MifDocument
+        ...
+
+    def from_mif(self, doc: MifDocument) -> str:
+        # Serialize MifDocument to your format
+        ...
+```
+
+### TypeScript
+
+```typescript
+import { MifAdapter, MifDocument } from "@varunshodh/mif-tools";
+
+class MyAdapter implements MifAdapter {
+  name() { return "My Format"; }
+  formatId() { return "myformat"; }
+  detect(data: string) { return data.includes('"my_marker"'); }
+  toMif(data: string): MifDocument { /* ... */ }
+  fromMif(doc: MifDocument): string { /* ... */ }
+}
+```
+
+Register your adapter:
+
+```python
+from mif.registry import AdapterRegistry
+registry = AdapterRegistry()
+registry.adapters.insert(0, MyAdapter())  # highest priority
+```
+
+```typescript
+import { AdapterRegistry } from "@varunshodh/mif-tools";
+const registry = new AdapterRegistry();
+registry.register(new MyAdapter()); // prepended for highest priority
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,95 @@
+---
+layout: default
+title: Home
+nav_order: 1
+---
+
+# Memory Interchange Format (MIF)
+
+A vendor-neutral JSON schema for portable AI agent memories.
+{: .fs-6 .fw-300 }
+
+---
+
+## The Problem
+
+AI memory is becoming standard infrastructure — but every system stores it differently. Switching providers means losing months of accumulated context. Memory servers can't compose. There's no vCard for AI memories.
+
+## The Solution
+
+MIF defines a minimal, extensible JSON envelope for memories and optional knowledge graph data. Export from any system, import into any other.
+
+```json
+{
+  "mif_version": "2.0",
+  "memories": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "content": "User prefers dark mode across all applications",
+      "memory_type": "observation",
+      "created_at": "2026-01-15T10:30:00Z",
+      "tags": ["preferences", "ui"]
+    }
+  ]
+}
+```
+
+## Quick Start
+
+### Python
+
+```bash
+pip install mif-tools
+```
+
+```python
+from mif import load, dump, convert
+
+# Auto-detect format and convert to MIF
+doc = load(open("memories.json").read())
+
+# Convert between formats
+result = convert(data, from_format="mem0", to_format="shodh")
+```
+
+### npm
+
+```bash
+npm install @varunshodh/mif-tools
+```
+
+```typescript
+import { load, dump, convert } from "@varunshodh/mif-tools";
+
+const doc = load(fs.readFileSync("memories.json", "utf-8"));
+const result = convert(data, { fromFormat: "mem0", toFormat: "shodh" });
+```
+
+### CLI
+
+```bash
+mif convert export.json --from mem0 --to shodh -o memories.mif.json
+mif validate memories.mif.json
+mif inspect memories.json
+mif formats
+```
+
+## Supported Formats
+
+| Format | ID | Description |
+|---|---|---|
+| MIF / Shodh | `shodh` | Native MIF v2 JSON (+ v1 backward compat) |
+| mem0 | `mem0` | mem0 JSON array format |
+| CrewAI | `crewai` | CrewAI LTMSQLiteStorage export |
+| LangChain | `langchain` | LangChain/LangMem Item format |
+| Generic JSON | `generic` | Any JSON array with `content` field |
+| Markdown | `markdown` | YAML frontmatter + body |
+
+## Links
+
+- [Full Specification](spec) - MIF v2.0 spec
+- [Adapter Reference](adapters) - All format adapters
+- [Python Package](python) - Python guide
+- [npm Package](npm) - npm/TypeScript guide
+- [MCP Server](mcp) - Model Context Protocol server
+- [GitHub Repository](https://github.com/varun29ankuS/mif-spec)

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,136 @@
+---
+layout: default
+title: MCP Server
+nav_order: 6
+---
+
+# MIF MCP Server
+
+The MIF MCP server exposes memory conversion and validation tools via the [Model Context Protocol](https://modelcontextprotocol.io), making MIF accessible to any MCP-compatible AI client.
+
+---
+
+## Installation
+
+```bash
+pip install mif-tools[mcp]
+```
+
+## Starting the Server
+
+```bash
+mif mcp
+```
+
+Or programmatically:
+
+```python
+from mif.mcp_server import create_server
+
+server = create_server()
+server.run()
+```
+
+## Available Tools
+
+### `export_memories`
+
+Convert memories from any supported format to MIF v2 JSON.
+
+**Parameters:**
+- `data` (string, required) — Input data string
+- `from_format` (string, optional) — Source format ID. Auto-detected if omitted.
+
+**Returns:** MIF v2 JSON string.
+
+### `import_memories`
+
+Convert MIF v2 JSON to a target format.
+
+**Parameters:**
+- `data` (string, required) — MIF v2 JSON string
+- `to_format` (string, optional) — Target format ID. Default: `shodh`
+
+**Returns:** Converted string in the target format.
+
+### `validate_memories`
+
+Validate a MIF JSON document against the schema and run semantic checks.
+
+**Parameters:**
+- `data` (string, required) — MIF JSON string
+
+**Returns:** JSON object with validation results:
+
+```json
+{
+  "valid": true,
+  "schema_valid": true,
+  "semantic_valid": true,
+  "semantic_warnings": [],
+  "summary": {
+    "memories": 42,
+    "has_graph": false,
+    "has_extensions": false
+  }
+}
+```
+
+### `list_formats`
+
+List all available memory format adapters.
+
+**Returns:** JSON array of format objects.
+
+```json
+[
+  { "name": "Shodh Memory (MIF v2/v1)", "format_id": "shodh" },
+  { "name": "mem0", "format_id": "mem0" },
+  { "name": "CrewAI", "format_id": "crewai" },
+  { "name": "LangChain", "format_id": "langchain" },
+  { "name": "Generic JSON", "format_id": "generic" },
+  { "name": "Markdown (YAML frontmatter)", "format_id": "markdown" }
+]
+```
+
+### `inspect_memories`
+
+Show a summary of a memory file.
+
+**Parameters:**
+- `data` (string, required) — Input data string
+- `from_format` (string, optional) — Source format ID
+
+**Returns:** JSON summary object.
+
+## MCP Client Configuration
+
+### Claude Desktop
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "mif": {
+      "command": "mif",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+### Claude Code
+
+Add to your MCP settings:
+
+```json
+{
+  "mcpServers": {
+    "mif": {
+      "command": "mif",
+      "args": ["mcp"]
+    }
+  }
+}
+```

--- a/docs/npm.md
+++ b/docs/npm.md
@@ -1,0 +1,117 @@
+---
+layout: default
+title: npm
+nav_order: 5
+---
+
+# npm Package
+
+`@varunshodh/mif-tools` — TypeScript/JavaScript library and CLI for MIF.
+
+---
+
+## Installation
+
+```bash
+npm install @varunshodh/mif-tools
+```
+
+## API Reference
+
+### `load(data, format?) -> MifDocument`
+
+Parse a string into a MifDocument. Auto-detects format unless specified.
+
+```typescript
+import { load } from "@varunshodh/mif-tools";
+
+const doc = load(fs.readFileSync("memories.json", "utf-8"));
+const doc2 = load(data, "mem0");
+```
+
+### `dump(doc, format?) -> string`
+
+Serialize a MifDocument to a string.
+
+```typescript
+import { dump } from "@varunshodh/mif-tools";
+
+const json = dump(doc);                     // MIF v2 JSON
+const md = dump(doc, "markdown");           // YAML frontmatter markdown
+```
+
+### `convert(data, options?) -> string`
+
+Convert between formats in one call.
+
+```typescript
+import { convert } from "@varunshodh/mif-tools";
+
+const result = convert(data, { fromFormat: "mem0", toFormat: "markdown" });
+```
+
+### `validate(data) -> [boolean, string[]]`
+
+Validate a MIF JSON string against the schema.
+
+```typescript
+import { validate } from "@varunshodh/mif-tools";
+
+const [isValid, errors] = validate(jsonString);
+```
+
+### `validateDeep(data) -> [boolean, string[]]`
+
+Semantic validation.
+
+```typescript
+import { validateDeep } from "@varunshodh/mif-tools";
+
+const [isValid, warnings] = validateDeep(jsonString);
+```
+
+### `deduplicate(doc) -> [MifDocument, number]`
+
+Deduplicate memories by SHA-256 content hash.
+
+```typescript
+import { deduplicate } from "@varunshodh/mif-tools";
+
+const [dedupedDoc, removedCount] = deduplicate(doc);
+```
+
+### `AdapterRegistry`
+
+Manage format adapters dynamically.
+
+```typescript
+import { AdapterRegistry } from "@varunshodh/mif-tools";
+
+const registry = new AdapterRegistry();
+registry.register(myAdapter);      // prepend custom adapter
+registry.unregister("myformat");   // remove by format ID
+registry.listFormats();            // list all adapters
+```
+
+## Models
+
+```typescript
+import { createMemory, createDocument } from "@varunshodh/mif-tools";
+
+const memory = createMemory({
+  content: "User prefers dark mode",
+  memory_type: "observation",
+  tags: ["preferences"],
+});
+
+const doc = createDocument({ memories: [memory] });
+```
+
+## CLI
+
+```bash
+npx mif convert export.json --from mem0 --to shodh -o output.mif.json
+npx mif validate file1.json file2.json
+npx mif inspect memories.json
+npx mif formats
+```

--- a/docs/python.md
+++ b/docs/python.md
@@ -1,0 +1,125 @@
+---
+layout: default
+title: Python
+nav_order: 4
+---
+
+# Python Package
+
+`mif-tools` — Python library and CLI for MIF.
+
+---
+
+## Installation
+
+```bash
+pip install mif-tools
+
+# With schema validation support
+pip install mif-tools[validate]
+
+# With MCP server support
+pip install mif-tools[mcp]
+```
+
+## API Reference
+
+### `load(data, *, format=None) -> MifDocument`
+
+Parse a string into a MifDocument. Auto-detects format unless specified.
+
+```python
+from mif import load
+
+doc = load(open("memories.json").read())
+doc = load(data, format="mem0")
+```
+
+### `dump(doc, *, format="shodh") -> str`
+
+Serialize a MifDocument to a string.
+
+```python
+from mif import dump
+
+json_str = dump(doc)                    # MIF v2 JSON
+md_str = dump(doc, format="markdown")   # YAML frontmatter markdown
+```
+
+### `convert(data, *, from_format=None, to_format="shodh") -> str`
+
+Convert between formats in one call.
+
+```python
+from mif import convert
+
+result = convert(data, from_format="mem0", to_format="markdown")
+```
+
+### `validate(data) -> tuple[bool, list[str]]`
+
+Validate a MIF JSON string against the schema.
+
+```python
+from mif import validate
+
+is_valid, errors = validate(json_string)
+```
+
+### `validate_deep(data) -> tuple[bool, list[str]]`
+
+Semantic validation (UUID format, referential integrity, timestamp ordering, embedding dimensions).
+
+```python
+from mif import validate_deep
+
+is_valid, warnings = validate_deep(json_string)
+```
+
+### `deduplicate(doc) -> tuple[MifDocument, int]`
+
+Deduplicate memories by SHA-256 content hash.
+
+```python
+from mif import deduplicate
+
+deduped_doc, removed_count = deduplicate(doc)
+```
+
+## Models
+
+```python
+from mif.models import Memory, MifDocument
+
+memory = Memory(
+    id="550e8400-e29b-41d4-a716-446655440000",
+    content="User prefers dark mode",
+    created_at="2026-01-15T10:30:00Z",
+    memory_type="observation",
+    tags=["preferences"],
+)
+
+doc = MifDocument(memories=[memory])
+```
+
+## CLI
+
+```bash
+# Convert between formats
+mif convert export.json --from mem0 --to shodh -o output.mif.json
+
+# Auto-detect source format
+mif convert memories.json --to markdown
+
+# Validate MIF documents
+mif validate file1.json file2.json
+
+# Inspect a memory file
+mif inspect memories.json
+
+# List available formats
+mif formats
+
+# Start MCP server (requires mif-tools[mcp])
+mif mcp
+```

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,0 +1,175 @@
+---
+layout: default
+title: Specification
+nav_order: 2
+---
+
+# MIF v2.0 Specification
+
+- **Version**: 2.0
+- **Status**: Draft
+- **Created**: 2026-03-03
+- **Author(s)**: Varun Sharma (@varun29ankuS)
+
+**Note:** v2.0 is the first public release. The "v2" numbering reflects internal iterations during development.
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+---
+
+## Abstract
+
+MIF is a vendor-neutral JSON schema for exchanging AI agent memories between systems. It defines a minimal, extensible envelope for memories and optional knowledge graph data, enabling portability across providers.
+
+## 1. Document Structure
+
+A MIF document is a JSON object:
+
+```json
+{
+  "mif_version": "2.0",
+  "generator": { "name": "example-memory", "version": "1.0.0" },
+  "export_meta": {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "created_at": "2026-03-03T10:00:00Z",
+    "user_id": "user-1",
+    "checksum": "sha256:abc123...",
+    "privacy": { "pii_detected": false, "redacted_fields": [] }
+  },
+  "memories": [],
+  "knowledge_graph": null,
+  "vendor_extensions": {}
+}
+```
+
+**Required fields:** `mif_version`, `memories`
+
+A minimal conforming document:
+
+```json
+{"mif_version": "2.0", "memories": []}
+```
+
+## 2. Memory Object
+
+Each entry in the `memories` array:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | string (UUID v4) | Yes | Unique identifier |
+| `content` | string | Yes | Memory content text |
+| `created_at` | string (ISO 8601) | Yes | Creation timestamp |
+| `memory_type` | string | No | Type classification |
+| `updated_at` | string (ISO 8601) | No | Last modification time |
+| `tags` | string[] | No | Classification tags |
+| `entities` | EntityReference[] | No | Referenced entities |
+| `metadata` | object | No | Arbitrary metadata |
+| `embeddings` | Embedding | No | Vector embedding |
+| `source` | Source | No | Origin information |
+| `parent_id` | string (UUID) \| null | No | Parent memory reference |
+| `related_memory_ids` | string[] (UUIDs) | No | Related memories |
+| `agent_id` | string \| null | No | Agent identifier |
+| `external_id` | string \| null | No | External system ID |
+| `version` | integer (>= 1) | No | Version number |
+
+### 2.1 Memory Types
+
+Lowercase snake_case strings. Common types:
+
+| Type | Description |
+|---|---|
+| `observation` | Factual observation about user or environment |
+| `decision` | A decision made by or for the user |
+| `learning` | Something learned during interaction |
+| `error` | An error and its context |
+| `context` | Session or project context |
+| `conversation` | Conversation excerpt or summary |
+
+This list is **non-exhaustive**. Implementations MUST accept unknown types without error and MUST preserve them on round-trip.
+
+### 2.2 Entity References
+
+```json
+{ "name": "RocksDB", "entity_type": "technology", "confidence": 0.95 }
+```
+
+Common entity types: `person`, `organization`, `location`, `technology`, `concept`, `event`, `product`, `unknown`.
+
+### 2.3 Embeddings
+
+Optional. When present:
+- Importers using the **same model** MAY reuse the vector directly
+- Importers using a **different model** SHOULD discard and regenerate from `content`
+- `dimensions` must equal `len(vector)`
+
+## 3. Knowledge Graph (Optional)
+
+```json
+{
+  "entities": [
+    {
+      "id": "...",
+      "name": "Rust",
+      "types": ["technology"],
+      "attributes": { "category": "programming_language" },
+      "summary": "Systems programming language"
+    }
+  ],
+  "relationships": [
+    {
+      "id": "...",
+      "source_entity_id": "...",
+      "target_entity_id": "...",
+      "relation_type": "works_with",
+      "confidence": 0.9
+    }
+  ]
+}
+```
+
+## 4. Vendor Extensions
+
+System-specific metadata lives in `vendor_extensions`, keyed by system name:
+
+```json
+"vendor_extensions": {
+  "shodh-memory": { "memory_metadata": { "<uuid>": { "importance": 0.85 } } },
+  "mem0": { "organization_id": "org-123" }
+}
+```
+
+Implementations MUST preserve vendor extensions from other systems on round-trip.
+
+## 5. Privacy
+
+The `export_meta.privacy` field communicates PII handling:
+
+```json
+{ "pii_detected": true, "redacted_fields": ["email", "phone"] }
+```
+
+## 6. Import Behavior
+
+- **UUID preservation:** Imported memories SHOULD retain original IDs
+- **Deduplication:** By content hash (SHA-256 of `content`), not UUID collision
+- **Partial failure:** Individual failures MUST NOT abort the batch
+- **Unknown fields:** Importers MUST ignore unknown fields (forward compatibility)
+
+## 7. MCP Tool Conventions
+
+Memory servers implementing MIF SHOULD expose:
+
+| Tool | Purpose |
+|---|---|
+| `export_memories` | Export user memories as MIF JSON |
+| `import_memories` | Import MIF JSON into the memory system |
+
+## 8. Versioning
+
+- **Minor versions (2.x)** are additive only — new optional fields, no breaking changes
+- A v2.0 consumer SHOULD accept any v2.x document
+- **Major versions (3.0+)** MAY introduce breaking changes
+
+## 9. JSON Schema
+
+A formal JSON Schema for validation: [`mif-v2.schema.json`](https://github.com/varun29ankuS/mif-spec/blob/main/schema/mif-v2.schema.json)

--- a/npm/src/adapters.ts
+++ b/npm/src/adapters.ts
@@ -369,3 +369,183 @@ function parseFrontmatter(fm: string): Record<string, string> {
   }
   return result;
 }
+
+// ---------------------------------------------------------------------------
+// CrewAI adapter (LTMSQLiteStorage JSON export)
+// ---------------------------------------------------------------------------
+
+export class CrewAIAdapter implements MifAdapter {
+  name() { return "CrewAI"; }
+  formatId() { return "crewai"; }
+
+  detect(data: string): boolean {
+    const t = data.trimStart();
+    if (!t.startsWith("[")) return false;
+    return t.includes('"task_description"');
+  }
+
+  toMif(data: string): MifDocument {
+    const items: any[] = JSON.parse(data);
+    const memories: Memory[] = [];
+
+    for (const item of items) {
+      const content = item.task_description;
+      if (!content) continue;
+
+      // Parse metadata (may be JSON string or object)
+      let metadata: Record<string, unknown> = {};
+      const rawMeta = item.metadata;
+      if (typeof rawMeta === "string") {
+        try { metadata = JSON.parse(rawMeta); } catch { metadata = { raw: rawMeta }; }
+      } else if (rawMeta && typeof rawMeta === "object") {
+        metadata = { ...rawMeta };
+      }
+
+      // Parse datetime (Unix timestamp string or ISO)
+      let created_at: string;
+      const rawDt = item.datetime;
+      if (rawDt) {
+        const ts = parseFloat(rawDt);
+        if (!isNaN(ts)) {
+          created_at = new Date(ts * 1000).toISOString();
+        } else {
+          created_at = parseDate(String(rawDt));
+        }
+      } else {
+        created_at = parseDate(null);
+      }
+
+      // Preserve score in metadata
+      if (item.score != null) {
+        metadata.score = item.score;
+      }
+
+      memories.push({
+        id: ensureUuid(),
+        content,
+        memory_type: "observation",
+        created_at,
+        metadata,
+        source: { source_type: "crewai" },
+      });
+    }
+
+    return {
+      mif_version: "2.0",
+      memories,
+      generator: { name: "crewai-import", version: "1.0" },
+    };
+  }
+
+  fromMif(doc: MifDocument): string {
+    const items = doc.memories.map(m => {
+      const meta = { ...(m.metadata || {}) };
+      const score = meta.score;
+      delete meta.score;
+
+      const obj: any = {
+        task_description: m.content,
+        metadata: JSON.stringify(meta),
+        datetime: String(new Date(m.created_at).getTime() / 1000),
+      };
+      if (score != null) obj.score = score;
+      return obj;
+    });
+    return JSON.stringify(items, null, 2);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// LangChain / LangMem adapter
+// ---------------------------------------------------------------------------
+
+export class LangChainAdapter implements MifAdapter {
+  name() { return "LangChain"; }
+  formatId() { return "langchain"; }
+
+  detect(data: string): boolean {
+    const t = data.trimStart();
+    if (!t.startsWith("[")) return false;
+    return t.includes('"namespace"') && t.includes('"value"');
+  }
+
+  toMif(data: string): MifDocument {
+    const items: any[] = JSON.parse(data);
+    const memories: Memory[] = [];
+
+    const typeMap: Record<string, string> = {
+      memory: "observation",
+      fact: "learning",
+      preference: "observation",
+      note: "observation",
+    };
+
+    for (const item of items) {
+      const value = item.value;
+      let content: string;
+      let kind = "";
+
+      if (typeof value === "string") {
+        content = value;
+      } else if (value && typeof value === "object") {
+        content = value.content || "";
+        kind = value.kind || "";
+      } else {
+        continue;
+      }
+
+      if (!content) continue;
+
+      const rawType = kind.toLowerCase() || "observation";
+      const memoryType = typeMap[rawType] || rawType || "observation";
+
+      // Namespace → tags
+      const namespace = item.namespace;
+      const tags: string[] = Array.isArray(namespace) ? namespace.map(String) : [];
+
+      // Metadata
+      const metadata: Record<string, unknown> = {};
+      if (item.score != null) metadata.score = item.score;
+
+      memories.push({
+        id: ensureUuid(),
+        content,
+        memory_type: memoryType,
+        created_at: parseDate(item.created_at),
+        updated_at: item.updated_at ? parseDate(item.updated_at) : undefined,
+        tags,
+        metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+        source: { source_type: "langchain" },
+        external_id: item.key || undefined,
+      });
+    }
+
+    return {
+      mif_version: "2.0",
+      memories,
+      generator: { name: "langchain-import", version: "1.0" },
+    };
+  }
+
+  fromMif(doc: MifDocument): string {
+    const items = doc.memories.map(m => {
+      const meta = { ...(m.metadata || {}) };
+      const score = meta.score;
+      delete meta.score;
+
+      const kind = (m.memory_type || "observation").charAt(0).toUpperCase()
+        + (m.memory_type || "observation").slice(1);
+
+      const obj: any = {
+        namespace: m.tags && m.tags.length > 0 ? m.tags : ["memories"],
+        key: m.external_id || m.id,
+        value: { kind, content: m.content },
+        created_at: m.created_at,
+      };
+      if (m.updated_at) obj.updated_at = m.updated_at;
+      if (score != null) obj.score = score;
+      return obj;
+    });
+    return JSON.stringify(items, null, 2);
+  }
+}

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -17,6 +17,8 @@ export type { MifAdapter } from "./adapters";
 export {
   ShodhAdapter,
   Mem0Adapter,
+  CrewAIAdapter,
+  LangChainAdapter,
   GenericJsonAdapter,
   MarkdownAdapter,
 } from "./adapters";
@@ -28,6 +30,8 @@ import {
   MifAdapter,
   ShodhAdapter,
   Mem0Adapter,
+  CrewAIAdapter,
+  LangChainAdapter,
   GenericJsonAdapter,
   MarkdownAdapter,
 } from "./adapters";
@@ -53,6 +57,8 @@ export class AdapterRegistry {
     this.adapters = [
       new ShodhAdapter(),
       new Mem0Adapter(),
+      new CrewAIAdapter(),
+      new LangChainAdapter(),
       new GenericJsonAdapter(),
       new MarkdownAdapter(),
     ];

--- a/npm/src/test.ts
+++ b/npm/src/test.ts
@@ -12,6 +12,8 @@ import {
 import {
   ShodhAdapter,
   Mem0Adapter,
+  CrewAIAdapter,
+  LangChainAdapter,
   GenericJsonAdapter,
   MarkdownAdapter,
 } from "./adapters";
@@ -870,7 +872,7 @@ console.log("\n--- listFormats() ---");
 
 {
   const fmts = listFormats();
-  assert(fmts.length === 4, "listFormats: returns 4 formats");
+  assert(fmts.length === 6, "listFormats: returns 6 formats");
   const ids = fmts.map(f => f.formatId);
   assert(ids.includes("shodh"), "listFormats: includes shodh");
   assert(ids.includes("mem0"), "listFormats: includes mem0");
@@ -1294,6 +1296,183 @@ console.log("\n=== Edge Cases ===");
   const v1NoVersion = JSON.stringify({ mif_version: "1", memories: [{ content: "x" }] });
   const doc = load(v1NoVersion, "shodh");
   assert(doc.generator?.version === "1", "edge: v1 generator version from source mif_version");
+}
+
+// ===================================================================
+// CrewAI Adapter Tests
+// ===================================================================
+console.log("\n--- CrewAI Adapter ---");
+
+const crewai = new CrewAIAdapter();
+const crewaiJson = JSON.stringify([
+  {
+    task_description: "User prefers dark mode for all IDEs",
+    metadata: JSON.stringify({ category: "preference", tool: "vscode" }),
+    datetime: "1718452800.0",
+    score: 0.95,
+  },
+  {
+    task_description: "Project uses PostgreSQL 16",
+    metadata: JSON.stringify({ category: "fact" }),
+    datetime: "1718539200.0",
+    score: 0.88,
+  },
+]);
+
+// detect
+assert(crewai.detect(crewaiJson), "crewai: detect crewai format");
+assert(!crewai.detect('[{"memory":"hello"}]'), "crewai: reject mem0");
+assert(!crewai.detect('{"task_description": "x"}'), "crewai: reject object");
+assert(!crewai.detect('[{"content":"hello"}]'), "crewai: reject generic");
+
+// toMif
+{
+  const doc = crewai.toMif(crewaiJson);
+  assert(doc.memories.length === 2, "crewai: toMif produces 2 memories");
+  assert(doc.generator?.name === "crewai-import", "crewai: generator name");
+  assert(doc.memories[0].content === "User prefers dark mode for all IDEs", "crewai: content mapped");
+  assert((doc.memories[0].metadata as any)?.category === "preference", "crewai: metadata parsed");
+  assert((doc.memories[0].metadata as any)?.score === 0.95, "crewai: score in metadata");
+  assert(doc.memories[0].memory_type === "observation", "crewai: memory type is observation");
+  assert(doc.memories[0].source?.source_type === "crewai", "crewai: source type");
+  assert(doc.memories[0].created_at.includes("2024-06-15"), "crewai: unix timestamp converted");
+  assert(doc.memories[0].id.length === 36, "crewai: generates UUID");
+}
+
+// toMif with dict metadata
+{
+  const data = JSON.stringify([{ task_description: "Test", metadata: { key: "value" } }]);
+  const doc = crewai.toMif(data);
+  assert((doc.memories[0].metadata as any)?.key === "value", "crewai: dict metadata preserved");
+}
+
+// toMif with invalid JSON metadata
+{
+  const data = JSON.stringify([{ task_description: "Test", metadata: "not json" }]);
+  const doc = crewai.toMif(data);
+  assert((doc.memories[0].metadata as any)?.raw === "not json", "crewai: invalid JSON metadata stored as raw");
+}
+
+// toMif skips empty
+{
+  const data = JSON.stringify([{ task_description: "" }, { task_description: "real" }]);
+  const doc = crewai.toMif(data);
+  assert(doc.memories.length === 1, "crewai: skips empty task_description");
+}
+
+// fromMif
+{
+  const doc = crewai.toMif(crewaiJson);
+  const output = crewai.fromMif(doc);
+  const items = JSON.parse(output);
+  assert(items.length === 2, "crewai: fromMif produces 2 items");
+  assert(items[0].task_description === "User prefers dark mode for all IDEs", "crewai: fromMif content");
+  assert("datetime" in items[0], "crewai: fromMif has datetime");
+  assert("metadata" in items[0], "crewai: fromMif has metadata");
+}
+
+// fromMif empty
+{
+  const doc: MifDocument = { mif_version: "2.0", memories: [] };
+  const output = crewai.fromMif(doc);
+  assertDeepEqual(JSON.parse(output), [], "crewai: fromMif empty");
+}
+
+// ===================================================================
+// LangChain Adapter Tests
+// ===================================================================
+console.log("\n--- LangChain Adapter ---");
+
+const langchain = new LangChainAdapter();
+const langchainJson = JSON.stringify([
+  {
+    namespace: ["memories", "user-prefs"],
+    key: "pref-dark-mode",
+    value: { kind: "Memory", content: "User prefers dark mode" },
+    created_at: "2025-06-15T12:00:00Z",
+    updated_at: "2025-06-15T13:00:00Z",
+    score: 0.9,
+  },
+  {
+    namespace: ["memories"],
+    key: "fact-postgres",
+    value: { kind: "Fact", content: "Project uses PostgreSQL" },
+    created_at: "2025-06-16T10:00:00Z",
+  },
+]);
+
+// detect
+assert(langchain.detect(langchainJson), "langchain: detect langchain format");
+assert(!langchain.detect('[{"memory":"hello"}]'), "langchain: reject mem0");
+assert(!langchain.detect('{"namespace": [], "value": {}}'), "langchain: reject object");
+assert(!langchain.detect('[{"content":"hello"}]'), "langchain: reject generic");
+
+// toMif
+{
+  const doc = langchain.toMif(langchainJson);
+  assert(doc.memories.length === 2, "langchain: toMif produces 2 memories");
+  assert(doc.generator?.name === "langchain-import", "langchain: generator name");
+  assert(doc.memories[0].content === "User prefers dark mode", "langchain: content from value");
+  assert(doc.memories[0].memory_type === "observation", "langchain: Memory kind → observation");
+  assert(doc.memories[1].memory_type === "learning", "langchain: Fact kind → learning");
+  assertDeepEqual(doc.memories[0].tags, ["memories", "user-prefs"], "langchain: namespace → tags");
+  assert(doc.memories[0].external_id === "pref-dark-mode", "langchain: key → external_id");
+  assert((doc.memories[0].metadata as any)?.score === 0.9, "langchain: score in metadata");
+  assert(doc.memories[0].updated_at != null, "langchain: updated_at preserved");
+  assert(doc.memories[0].source?.source_type === "langchain", "langchain: source type");
+  assert(doc.memories[0].id.length === 36, "langchain: generates UUID");
+}
+
+// toMif with string value
+{
+  const data = JSON.stringify([{
+    namespace: ["test"],
+    key: "k1",
+    value: "plain text content",
+    created_at: "2025-01-01T00:00:00Z",
+  }]);
+  const doc = langchain.toMif(data);
+  assert(doc.memories[0].content === "plain text content", "langchain: string value as content");
+}
+
+// toMif skips empty content
+{
+  const data = JSON.stringify([
+    { namespace: [], key: "k1", value: { content: "" } },
+    { namespace: [], key: "k2", value: { content: "real" } },
+  ]);
+  const doc = langchain.toMif(data);
+  assert(doc.memories.length === 1, "langchain: skips empty content");
+}
+
+// fromMif
+{
+  const doc = langchain.toMif(langchainJson);
+  const output = langchain.fromMif(doc);
+  const items = JSON.parse(output);
+  assert(items.length === 2, "langchain: fromMif produces 2 items");
+  assert(items[0].value.content === "User prefers dark mode", "langchain: fromMif value.content");
+  assert(items[0].value.kind === "Observation", "langchain: fromMif value.kind capitalized");
+  assert(Array.isArray(items[0].namespace), "langchain: fromMif has namespace array");
+  assert("key" in items[0], "langchain: fromMif has key");
+}
+
+// fromMif default namespace
+{
+  const doc: MifDocument = {
+    mif_version: "2.0",
+    memories: [{ id: "11111111-2222-3333-4444-555555555555", content: "x", created_at: "2025-01-01T00:00:00Z" }],
+  };
+  const output = langchain.fromMif(doc);
+  const items = JSON.parse(output);
+  assertDeepEqual(items[0].namespace, ["memories"], "langchain: fromMif default namespace");
+}
+
+// fromMif empty
+{
+  const doc: MifDocument = { mif_version: "2.0", memories: [] };
+  const output = langchain.fromMif(doc);
+  assertDeepEqual(JSON.parse(output), [], "langchain: fromMif empty");
 }
 
 // ===================================================================

--- a/python/mif/__init__.py
+++ b/python/mif/__init__.py
@@ -1,6 +1,7 @@
 """MIF (Memory Interchange Format) — vendor-neutral memory portability for AI agents."""
 
 from mif.models import MifDocument, Memory, KnowledgeGraph, GraphEntity, GraphRelationship
+from mif.adapters import CrewAIAdapter, LangChainAdapter
 from mif.registry import AdapterRegistry, load, dump, convert, validate, validate_deep, deduplicate
 
 __version__ = "0.1.0"
@@ -10,6 +11,8 @@ __all__ = [
     "KnowledgeGraph",
     "GraphEntity",
     "GraphRelationship",
+    "CrewAIAdapter",
+    "LangChainAdapter",
     "AdapterRegistry",
     "load",
     "dump",

--- a/python/mif/adapters.py
+++ b/python/mif/adapters.py
@@ -445,3 +445,212 @@ def _parse_frontmatter(fm: str) -> dict[str, str]:
             if key:
                 result[key] = value
     return result
+
+
+# ---------------------------------------------------------------------------
+# CrewAI adapter (LTMSQLiteStorage JSON export)
+# ---------------------------------------------------------------------------
+
+class CrewAIAdapter(MifAdapter):
+    """Convert CrewAI long-term memory exports to/from MIF.
+
+    CrewAI's LTMSQLiteStorage stores rows with:
+      task_description, metadata (JSON string), datetime (Unix timestamp string), score
+    """
+
+    def name(self) -> str:
+        return "CrewAI"
+
+    def format_id(self) -> str:
+        return "crewai"
+
+    def detect(self, data: str) -> bool:
+        trimmed = data.lstrip()
+        if not trimmed.startswith("["):
+            return False
+        return '"task_description"' in trimmed
+
+    def to_mif(self, data: str) -> MifDocument:
+        items = json.loads(data)
+        if not isinstance(items, list):
+            raise ValueError("CrewAI format requires a JSON array")
+
+        memories = []
+        for item in items:
+            content = item.get("task_description", "")
+            if not content:
+                continue
+
+            # Parse metadata (may be JSON string or dict)
+            raw_meta = item.get("metadata", {})
+            if isinstance(raw_meta, str):
+                try:
+                    metadata = json.loads(raw_meta)
+                except (json.JSONDecodeError, TypeError):
+                    metadata = {"raw": raw_meta}
+            elif isinstance(raw_meta, dict):
+                metadata = dict(raw_meta)
+            else:
+                metadata = {}
+
+            # Parse datetime (Unix timestamp string or ISO)
+            raw_dt = item.get("datetime")
+            if raw_dt:
+                try:
+                    ts = float(raw_dt)
+                    created_at = datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+                except (ValueError, TypeError, OSError):
+                    created_at = _parse_datetime(str(raw_dt))
+            else:
+                created_at = _parse_datetime(None)
+
+            # Preserve score in metadata
+            score = item.get("score")
+            if score is not None:
+                metadata["score"] = score
+
+            memories.append(Memory(
+                id=_ensure_uuid(None),
+                content=content,
+                memory_type="observation",
+                created_at=created_at,
+                metadata=metadata,
+                source=Source(source_type="crewai"),
+            ))
+
+        return MifDocument(
+            memories=memories,
+            generator={"name": "crewai-import", "version": "1.0"},
+        )
+
+    def from_mif(self, doc: MifDocument) -> str:
+        items = []
+        for m in doc.memories:
+            meta = dict(m.metadata) if m.metadata else {}
+            score = meta.pop("score", None)
+
+            obj: dict[str, Any] = {
+                "task_description": m.content,
+                "metadata": json.dumps(meta, ensure_ascii=False) if meta else "{}",
+                "datetime": str(datetime.fromisoformat(
+                    m.created_at.replace("Z", "+00:00")
+                ).timestamp()),
+            }
+            if score is not None:
+                obj["score"] = score
+
+            items.append(obj)
+        return json.dumps(items, indent=2, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# LangChain / LangMem adapter
+# ---------------------------------------------------------------------------
+
+class LangChainAdapter(MifAdapter):
+    """Convert LangChain/LangMem memory Item exports to/from MIF.
+
+    LangMem's Item format:
+      namespace (list[str]), key, value ({kind, content}),
+      created_at, updated_at, score
+    """
+
+    def name(self) -> str:
+        return "LangChain"
+
+    def format_id(self) -> str:
+        return "langchain"
+
+    def detect(self, data: str) -> bool:
+        trimmed = data.lstrip()
+        if not trimmed.startswith("["):
+            return False
+        return '"namespace"' in trimmed and '"value"' in trimmed
+
+    def to_mif(self, data: str) -> MifDocument:
+        items = json.loads(data)
+        if not isinstance(items, list):
+            raise ValueError("LangChain format requires a JSON array")
+
+        memories = []
+        for item in items:
+            value = item.get("value", {})
+            if isinstance(value, str):
+                content = value
+            elif isinstance(value, dict):
+                content = value.get("content", "")
+            else:
+                continue
+
+            if not content:
+                continue
+
+            # Map kind → memory_type
+            kind = ""
+            if isinstance(value, dict):
+                kind = value.get("kind", "")
+            memory_type = kind.lower() if kind else "observation"
+            # Normalise known types
+            type_map = {
+                "memory": "observation",
+                "fact": "learning",
+                "preference": "observation",
+                "note": "observation",
+            }
+            memory_type = type_map.get(memory_type, memory_type) or "observation"
+
+            # Namespace → tags
+            namespace = item.get("namespace", [])
+            tags = [str(ns) for ns in namespace] if isinstance(namespace, list) else []
+
+            # Metadata
+            metadata: dict[str, Any] = {}
+            score = item.get("score")
+            if score is not None:
+                metadata["score"] = score
+
+            created_at = _parse_datetime(item.get("created_at"))
+            updated_at_raw = item.get("updated_at")
+            updated_at = _parse_datetime(updated_at_raw) if updated_at_raw else None
+
+            memories.append(Memory(
+                id=_ensure_uuid(None),
+                content=content,
+                memory_type=memory_type,
+                created_at=created_at,
+                updated_at=updated_at,
+                tags=tags,
+                metadata=metadata if metadata else None,
+                source=Source(source_type="langchain"),
+                external_id=item.get("key"),
+            ))
+
+        return MifDocument(
+            memories=memories,
+            generator={"name": "langchain-import", "version": "1.0"},
+        )
+
+    def from_mif(self, doc: MifDocument) -> str:
+        items = []
+        for m in doc.memories:
+            meta = dict(m.metadata) if m.metadata else {}
+            score = meta.pop("score", None)
+
+            kind = (m.memory_type or "observation").capitalize()
+
+            obj: dict[str, Any] = {
+                "namespace": m.tags if m.tags else ["memories"],
+                "key": m.external_id or m.id,
+                "value": {
+                    "kind": kind,
+                    "content": m.content,
+                },
+                "created_at": m.created_at,
+            }
+            if m.updated_at:
+                obj["updated_at"] = m.updated_at
+            if score is not None:
+                obj["score"] = score
+
+            items.append(obj)
+        return json.dumps(items, indent=2, ensure_ascii=False)

--- a/python/mif/cli.py
+++ b/python/mif/cli.py
@@ -33,6 +33,9 @@ def main():
     # formats
     subparsers.add_parser("formats", help="List available formats")
 
+    # mcp
+    subparsers.add_parser("mcp", help="Start MIF MCP server (requires pip install mif-tools[mcp])")
+
     args = parser.parse_args()
 
     if args.command == "convert":
@@ -43,6 +46,8 @@ def main():
         cmd_inspect(args)
     elif args.command == "formats":
         cmd_formats()
+    elif args.command == "mcp":
+        cmd_mcp()
     else:
         parser.print_help()
         sys.exit(1)
@@ -137,6 +142,15 @@ def cmd_formats():
     print("Usage:")
     print("  mif convert input.json --from mem0 --to shodh -o output.mif.json")
     print("  mif convert input.json --to markdown    # auto-detect source")
+
+
+def cmd_mcp():
+    try:
+        from mif.mcp_server import main as mcp_main
+        mcp_main()
+    except ImportError:
+        print("MCP dependencies not installed. Run: pip install mif-tools[mcp]")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/python/mif/mcp_server.py
+++ b/python/mif/mcp_server.py
@@ -1,0 +1,134 @@
+"""MIF MCP Server — expose MIF tools via Model Context Protocol."""
+
+from __future__ import annotations
+
+import json
+
+from mif.registry import AdapterRegistry, load, dump, validate, validate_deep
+
+_registry = AdapterRegistry()
+
+
+def create_server():
+    """Create and return a FastMCP server with MIF tools."""
+    from mcp.server.fastmcp import FastMCP
+
+    mcp = FastMCP(
+        "MIF Tools",
+        description="Memory Interchange Format — convert, validate, and inspect AI agent memories",
+    )
+
+    @mcp.tool()
+    def export_memories(
+        data: str,
+        from_format: str | None = None,
+    ) -> str:
+        """Convert memories from any supported format to MIF v2 JSON.
+
+        Args:
+            data: Input data string (JSON, markdown, etc.)
+            from_format: Source format ID (auto-detected if omitted).
+                         Options: shodh, mem0, crewai, langchain, generic, markdown
+        """
+        doc = load(data, format=from_format)
+        return dump(doc, format="shodh")
+
+    @mcp.tool()
+    def import_memories(
+        data: str,
+        to_format: str = "shodh",
+    ) -> str:
+        """Convert MIF v2 JSON to a target format.
+
+        Args:
+            data: MIF v2 JSON string
+            to_format: Target format ID.
+                       Options: shodh, mem0, crewai, langchain, generic, markdown
+        """
+        doc = load(data, format="shodh")
+        return dump(doc, format=to_format)
+
+    @mcp.tool()
+    def validate_memories(data: str) -> str:
+        """Validate a MIF JSON document against the schema and run semantic checks.
+
+        Args:
+            data: MIF JSON string to validate
+
+        Returns:
+            JSON object with validation results
+        """
+        schema_ok, schema_errors = validate(data)
+        if not schema_ok:
+            return json.dumps({
+                "valid": False,
+                "schema_errors": schema_errors,
+            }, indent=2)
+
+        deep_ok, deep_warnings = validate_deep(data)
+        doc = load(data)
+        return json.dumps({
+            "valid": True,
+            "schema_valid": True,
+            "semantic_valid": deep_ok,
+            "semantic_warnings": deep_warnings,
+            "summary": {
+                "memories": len(doc.memories),
+                "has_graph": doc.knowledge_graph is not None,
+                "has_extensions": bool(doc.vendor_extensions),
+            },
+        }, indent=2)
+
+    @mcp.tool()
+    def list_formats() -> str:
+        """List all available memory format adapters.
+
+        Returns:
+            JSON array of format objects with name and format_id
+        """
+        formats = _registry.list_formats()
+        return json.dumps(formats, indent=2)
+
+    @mcp.tool()
+    def inspect_memories(
+        data: str,
+        from_format: str | None = None,
+    ) -> str:
+        """Show a summary of a memory file.
+
+        Args:
+            data: Input data string
+            from_format: Source format ID (auto-detected if omitted)
+        """
+        doc = load(data, format=from_format)
+
+        types: dict[str, int] = {}
+        all_tags: set[str] = set()
+        for m in doc.memories:
+            types[m.memory_type] = types.get(m.memory_type, 0) + 1
+            all_tags.update(m.tags)
+
+        result = {
+            "mif_version": doc.mif_version,
+            "memory_count": len(doc.memories),
+            "types": types,
+            "tags": sorted(all_tags),
+            "has_graph": doc.knowledge_graph is not None,
+            "has_extensions": bool(doc.vendor_extensions),
+        }
+        if doc.generator:
+            result["generator"] = doc.generator
+
+        return json.dumps(result, indent=2)
+
+    return mcp
+
+
+def main():
+    """Run the MIF MCP server."""
+    server = create_server()
+    server.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/mif/registry.py
+++ b/python/mif/registry.py
@@ -14,6 +14,8 @@ from mif.adapters import (
     MifAdapter,
     ShodhAdapter,
     Mem0Adapter,
+    CrewAIAdapter,
+    LangChainAdapter,
     GenericJsonAdapter,
     MarkdownAdapter,
 )
@@ -34,6 +36,8 @@ class AdapterRegistry:
         self.adapters: list[MifAdapter] = [
             ShodhAdapter(),
             Mem0Adapter(),
+            CrewAIAdapter(),
+            LangChainAdapter(),
             GenericJsonAdapter(),
             MarkdownAdapter(),
         ]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = []
 
 [project.optional-dependencies]
 validate = ["jsonschema>=4.20.0"]
+mcp = ["mcp>=1.0"]
 
 [project.scripts]
 mif = "mif.cli:main"

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -194,3 +194,43 @@ def markdown_multi():
         "---\n"
         "Decided to use FastAPI.\n"
     )
+
+
+@pytest.fixture
+def crewai_json():
+    """A CrewAI LTMSQLiteStorage export."""
+    return json.dumps([
+        {
+            "task_description": "User prefers dark mode for all IDEs",
+            "metadata": json.dumps({"category": "preference", "tool": "vscode"}),
+            "datetime": "1718452800.0",
+            "score": 0.95,
+        },
+        {
+            "task_description": "Project uses PostgreSQL 16",
+            "metadata": json.dumps({"category": "fact"}),
+            "datetime": "1718539200.0",
+            "score": 0.88,
+        },
+    ])
+
+
+@pytest.fixture
+def langchain_json():
+    """A LangChain/LangMem Item export."""
+    return json.dumps([
+        {
+            "namespace": ["memories", "user-prefs"],
+            "key": "pref-dark-mode",
+            "value": {"kind": "Memory", "content": "User prefers dark mode"},
+            "created_at": "2025-06-15T12:00:00Z",
+            "updated_at": "2025-06-15T13:00:00Z",
+            "score": 0.9,
+        },
+        {
+            "namespace": ["memories"],
+            "key": "fact-postgres",
+            "value": {"kind": "Fact", "content": "Project uses PostgreSQL"},
+            "created_at": "2025-06-16T10:00:00Z",
+        },
+    ])

--- a/python/tests/test_adapters.py
+++ b/python/tests/test_adapters.py
@@ -8,6 +8,8 @@ import pytest
 from mif.adapters import (
     ShodhAdapter,
     Mem0Adapter,
+    CrewAIAdapter,
+    LangChainAdapter,
     GenericJsonAdapter,
     MarkdownAdapter,
 )
@@ -592,3 +594,241 @@ class TestMarkdownAdapter:
     def test_to_mif_no_frontmatter(self):
         doc = self.adapter.to_mif("just plain text\nno frontmatter")
         assert doc.memories == []
+
+
+# ── CrewAIAdapter ────────────────────────────────────────────────────────
+
+class TestCrewAIAdapter:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.adapter = CrewAIAdapter()
+
+    def test_name_and_format_id(self):
+        assert self.adapter.name() == "CrewAI"
+        assert self.adapter.format_id() == "crewai"
+
+    # ── detect ──
+
+    def test_detect_crewai(self, crewai_json):
+        assert self.adapter.detect(crewai_json) is True
+
+    def test_detect_rejects_mem0(self, mem0_json):
+        assert self.adapter.detect(mem0_json) is False
+
+    def test_detect_rejects_object(self):
+        assert self.adapter.detect('{"task_description": "test"}') is False
+
+    def test_detect_rejects_generic(self, generic_json):
+        assert self.adapter.detect(generic_json) is False
+
+    # ── to_mif ──
+
+    def test_to_mif_basic(self, crewai_json):
+        doc = self.adapter.to_mif(crewai_json)
+        assert len(doc.memories) == 2
+        assert doc.generator["name"] == "crewai-import"
+
+    def test_to_mif_content_mapped(self, crewai_json):
+        doc = self.adapter.to_mif(crewai_json)
+        assert doc.memories[0].content == "User prefers dark mode for all IDEs"
+
+    def test_to_mif_metadata_parsed(self, crewai_json):
+        doc = self.adapter.to_mif(crewai_json)
+        assert doc.memories[0].metadata["category"] == "preference"
+        assert doc.memories[0].metadata["tool"] == "vscode"
+
+    def test_to_mif_score_in_metadata(self, crewai_json):
+        doc = self.adapter.to_mif(crewai_json)
+        assert doc.memories[0].metadata["score"] == 0.95
+
+    def test_to_mif_datetime_unix(self, crewai_json):
+        doc = self.adapter.to_mif(crewai_json)
+        assert "2024-06-15" in doc.memories[0].created_at
+
+    def test_to_mif_source_set(self, crewai_json):
+        doc = self.adapter.to_mif(crewai_json)
+        assert doc.memories[0].source.source_type == "crewai"
+
+    def test_to_mif_memory_type_observation(self, crewai_json):
+        doc = self.adapter.to_mif(crewai_json)
+        assert doc.memories[0].memory_type == "observation"
+
+    def test_to_mif_metadata_as_dict(self):
+        data = json.dumps([{
+            "task_description": "Test",
+            "metadata": {"key": "value"},
+        }])
+        doc = self.adapter.to_mif(data)
+        assert doc.memories[0].metadata["key"] == "value"
+
+    def test_to_mif_metadata_invalid_json(self):
+        data = json.dumps([{
+            "task_description": "Test",
+            "metadata": "not json",
+        }])
+        doc = self.adapter.to_mif(data)
+        assert doc.memories[0].metadata["raw"] == "not json"
+
+    def test_to_mif_skips_empty(self):
+        data = json.dumps([
+            {"task_description": ""},
+            {"task_description": "real"},
+        ])
+        doc = self.adapter.to_mif(data)
+        assert len(doc.memories) == 1
+
+    def test_to_mif_non_array_raises(self):
+        with pytest.raises(ValueError, match="JSON array"):
+            self.adapter.to_mif('{"task_description": "test"}')
+
+    def test_to_mif_generates_uuid(self, crewai_json):
+        doc = self.adapter.to_mif(crewai_json)
+        uuid.UUID(doc.memories[0].id)
+
+    # ── from_mif ──
+
+    def test_from_mif_basic(self, sample_mif_doc):
+        output = self.adapter.from_mif(sample_mif_doc)
+        items = json.loads(output)
+        assert isinstance(items, list)
+        assert len(items) == 1
+        assert "task_description" in items[0]
+        assert "datetime" in items[0]
+
+    def test_from_mif_roundtrip(self, crewai_json):
+        doc = self.adapter.to_mif(crewai_json)
+        output = self.adapter.from_mif(doc)
+        items = json.loads(output)
+        assert len(items) == 2
+        assert items[0]["task_description"] == "User prefers dark mode for all IDEs"
+
+    def test_from_mif_empty(self):
+        doc = MifDocument(memories=[])
+        output = self.adapter.from_mif(doc)
+        assert json.loads(output) == []
+
+
+# ── LangChainAdapter ─────────────────────────────────────────────────────
+
+class TestLangChainAdapter:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.adapter = LangChainAdapter()
+
+    def test_name_and_format_id(self):
+        assert self.adapter.name() == "LangChain"
+        assert self.adapter.format_id() == "langchain"
+
+    # ── detect ──
+
+    def test_detect_langchain(self, langchain_json):
+        assert self.adapter.detect(langchain_json) is True
+
+    def test_detect_rejects_mem0(self, mem0_json):
+        assert self.adapter.detect(mem0_json) is False
+
+    def test_detect_rejects_object(self):
+        assert self.adapter.detect('{"namespace": [], "value": {}}') is False
+
+    def test_detect_rejects_generic(self, generic_json):
+        assert self.adapter.detect(generic_json) is False
+
+    # ── to_mif ──
+
+    def test_to_mif_basic(self, langchain_json):
+        doc = self.adapter.to_mif(langchain_json)
+        assert len(doc.memories) == 2
+        assert doc.generator["name"] == "langchain-import"
+
+    def test_to_mif_content_from_value(self, langchain_json):
+        doc = self.adapter.to_mif(langchain_json)
+        assert doc.memories[0].content == "User prefers dark mode"
+
+    def test_to_mif_kind_to_memory_type(self, langchain_json):
+        doc = self.adapter.to_mif(langchain_json)
+        assert doc.memories[0].memory_type == "observation"  # "Memory" → observation
+        assert doc.memories[1].memory_type == "learning"  # "Fact" → learning
+
+    def test_to_mif_namespace_to_tags(self, langchain_json):
+        doc = self.adapter.to_mif(langchain_json)
+        assert doc.memories[0].tags == ["memories", "user-prefs"]
+
+    def test_to_mif_key_to_external_id(self, langchain_json):
+        doc = self.adapter.to_mif(langchain_json)
+        assert doc.memories[0].external_id == "pref-dark-mode"
+
+    def test_to_mif_score_in_metadata(self, langchain_json):
+        doc = self.adapter.to_mif(langchain_json)
+        assert doc.memories[0].metadata["score"] == 0.9
+
+    def test_to_mif_updated_at(self, langchain_json):
+        doc = self.adapter.to_mif(langchain_json)
+        assert doc.memories[0].updated_at is not None
+        assert "2025-06-15" in doc.memories[0].updated_at
+
+    def test_to_mif_source_set(self, langchain_json):
+        doc = self.adapter.to_mif(langchain_json)
+        assert doc.memories[0].source.source_type == "langchain"
+
+    def test_to_mif_value_as_string(self):
+        data = json.dumps([{
+            "namespace": ["test"],
+            "key": "k1",
+            "value": "plain text content",
+            "created_at": "2025-01-01T00:00:00Z",
+        }])
+        doc = self.adapter.to_mif(data)
+        assert doc.memories[0].content == "plain text content"
+
+    def test_to_mif_skips_empty_content(self):
+        data = json.dumps([
+            {"namespace": [], "key": "k1", "value": {"content": ""}},
+            {"namespace": [], "key": "k2", "value": {"content": "real"}},
+        ])
+        doc = self.adapter.to_mif(data)
+        assert len(doc.memories) == 1
+
+    def test_to_mif_non_array_raises(self):
+        with pytest.raises(ValueError, match="JSON array"):
+            self.adapter.to_mif('{"namespace": [], "value": {}}')
+
+    def test_to_mif_generates_uuid(self, langchain_json):
+        doc = self.adapter.to_mif(langchain_json)
+        uuid.UUID(doc.memories[0].id)
+
+    # ── from_mif ──
+
+    def test_from_mif_basic(self, sample_mif_doc):
+        output = self.adapter.from_mif(sample_mif_doc)
+        items = json.loads(output)
+        assert isinstance(items, list)
+        assert len(items) == 1
+        assert "namespace" in items[0]
+        assert "key" in items[0]
+        assert "value" in items[0]
+
+    def test_from_mif_value_structure(self, sample_mif_doc):
+        output = self.adapter.from_mif(sample_mif_doc)
+        items = json.loads(output)
+        assert "kind" in items[0]["value"]
+        assert "content" in items[0]["value"]
+
+    def test_from_mif_default_namespace(self):
+        doc = MifDocument(memories=[
+            Memory(id=str(uuid.uuid4()), content="x", created_at="2025-01-01T00:00:00Z"),
+        ])
+        output = self.adapter.from_mif(doc)
+        items = json.loads(output)
+        assert items[0]["namespace"] == ["memories"]
+
+    def test_from_mif_roundtrip(self, langchain_json):
+        doc = self.adapter.to_mif(langchain_json)
+        output = self.adapter.from_mif(doc)
+        items = json.loads(output)
+        assert len(items) == 2
+        assert items[0]["value"]["content"] == "User prefers dark mode"
+
+    def test_from_mif_empty(self):
+        doc = MifDocument(memories=[])
+        output = self.adapter.from_mif(doc)
+        assert json.loads(output) == []


### PR DESCRIPTION
## Summary

- **CrewAI adapter** (Python + npm): Converts CrewAI LTMSQLiteStorage exports (task_description, metadata JSON string, Unix timestamps, score) to/from MIF v2
- **LangChain adapter** (Python + npm): Converts LangChain/LangMem Item format (namespace, key, value.kind/content, score) to/from MIF v2
- **MIF MCP server** (Python): 5 tools via FastMCP — export_memories, import_memories, validate_memories, list_formats, inspect_memories. Start with `mif mcp`
- **GitHub Pages docs site**: Full documentation at varun29ankus.github.io/mif-spec using just-the-docs theme — spec reference, adapter guide, Python/npm/MCP docs

6 format adapters total: shodh, mem0, crewai, langchain, generic, markdown

## Test plan

- [x] 289 Python tests passing (42 new adapter tests)
- [x] 426 npm tests passing (47 new adapter tests)
- [ ] Verify GitHub Pages deploys after merge
- [ ] Verify `mif mcp` starts server with `pip install -e ".[mcp]"`